### PR TITLE
tests: adapt test data to SwiftCash specifics

### DIFF
--- a/contrib/testgen/base58.py
+++ b/contrib/testgen/base58.py
@@ -6,11 +6,7 @@ Bitcoin base58 encoding and decoding.
 
 Based on https://bitcointalk.org/index.php?topic=1026.0 (public domain)
 '''
-import hashlib
-
-# for compatibility with following code...
-class SHA256:
-    new = hashlib.sha256
+import sha3
 
 if str != bytes:
     # Python 3.x
@@ -72,8 +68,10 @@ def b58decode(v, length = None):
     return result
 
 def checksum(v):
-    """Return 32-bit checksum based on SHA256"""
-    return SHA256.new(SHA256.new(v).digest()).digest()[0:4]
+    """Return 32-bit checksum based on KECCAK_256"""
+    k = sha3.keccak_256()
+    k.update(v)
+    return k.digest()[0:4]
 
 def b58encode_chk(v):
     """b58encode a string, with 32-bit checksum"""

--- a/contrib/testgen/gen_base58_test_vectors.py
+++ b/contrib/testgen/gen_base58_test_vectors.py
@@ -18,12 +18,12 @@ import random
 from binascii import b2a_hex
 
 # key types
-PUBKEY_ADDRESS = 38
-SCRIPT_ADDRESS = 6
-PUBKEY_ADDRESS_TEST = 98
-SCRIPT_ADDRESS_TEST = 12
-PRIVKEY = 46
-PRIVKEY_TEST = 108
+PUBKEY_ADDRESS = 63
+SCRIPT_ADDRESS = 18
+PUBKEY_ADDRESS_TEST = 65
+SCRIPT_ADDRESS_TEST = 11
+PRIVKEY = 191
+PRIVKEY_TEST = 188
 
 metadata_keys = ['isPrivkey', 'isTestnet', 'addrType', 'isCompressed']
 # templates for valid sequences

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_SUITE(Checkpoints_tests)
 
 BOOST_AUTO_TEST_CASE(sanity)
 {
-    uint256 p0 = uint256("0x000008467c3a9c587533dea06ad9380cded3ed32f9742a6c0c1aebc21bf2bc9b");	/*	Block 0 */
+    uint256 p0 = uint256("0x000001211fb1c1d0cf722e8934ecc1d6dac522e0489657a8cd6b5ea288f8729b");	/*	Block 0 */
     uint256 p1 = uint256("0xc7aafa648a0f1450157dc93bd4d7448913a85b7448f803b4ab970d91fc2a7da7");
     BOOST_CHECK(Checkpoints::CheckBlock(0, p0));
 

--- a/src/test/data/base58_keys_invalid.json
+++ b/src/test/data/base58_keys_invalid.json
@@ -6,147 +6,147 @@
         "x"
     ], 
     [
-        "3Tt8pZfH1ddkSfhXG3TVLr7znVBr4w833Af"
+        "QRQDca6QkmgZUKR4RE66dhPrdnFyuS7dcRDAHgbiJXDWXuECgbC94Jf83kbwiqbpkZxhLMuVALy"
     ], 
     [
-        "5WcjGHnUD97qAvSfHnTkhzGVtquQm4AYXdmUrLKVLvnrh6XzdFLnxn1wAVSGwz6rq8xuzMtQc3K"
+        "6BDeqQjTw7jGe3mUj4s36V72xqhqopJb9YUBmv75Vm95F33NkGtiFpyaQuxN2mdZMXXvLfEKwycCr"
     ], 
     [
-        "7JutCUubcfP6G6dwbz1k96Ym4zjhur9WWP5WHYq2YCdN5h7Dnww"
+        "2XFqVyU2CTJoExF34Q4217nL49UYMAwEa7e"
     ], 
     [
-        "3CMNYKTXhJ3VBndCxDbRwXH2mvVzvzUWhZgkV59gihEDuFfYNQ3NBBaoYV66cbuzG52kfTv8KyB"
+        "QMB84nf4qVcoArr4JcQB2Qxb7HtP7JS3W96bFZXEkmFhGVMvKQtnY42NnXA4qXaKiLYsLxL675n"
     ], 
     [
-        "2U5pQrYtu7Jpq3YRgTzsHMTzbRC5v3hkU3D"
+        "5aY3sc54naFWyMuhTrrFAhFo1R6uBUndhG"
     ], 
     [
-        "5NEx9zU8Torzuy7UD6iEqLdyRg7mFtJSoWRYCyVbn2jhN3eecQnh2ZjuiMNQ3gBkjvP778691SE"
+        "2Dxo75gt8HQudCLtdWutKpHa7hG7a1ivH8jPoY8hmbP6Pay5CAr5uBudXUwBXEbjGUNiMXbUeSRH"
     ], 
     [
-        "7vn1T4kAS3gEmNGmhwVmnWWU3T8Uz3yYG3cAL6xdZVSK1tUnCtCy"
+        "66Lr2tb6uDyVfmWUfyPK4YmRCu12nUG727SHhihEhtoNiLqiBg4hStnRDPQHGNYdaU6T5EuMSRKpk"
     ], 
     [
-        "fbSY9aJtVwv56FU76gvhRSyYqw4bQ3KqRuRhc27U9nmpBpdtpsyuDxkFqmDmGzXcjW96s8QGktF"
+        "LDe3JnZCjjj3LGAFrxKvDebHkHP4hBhMqc"
     ], 
     [
-        "3PVgcmU9igAgvzBZQJfnZ56KRvK287vkYeHHjnyUwsHGKTArcdy4vF35HnxuAgxiQmo1vdTxsV4"
+        "4MoeaagzNnbDqgx2ZBfMdzVb5JiqkntQT1rDVewGpYvsE3iGxeW"
     ], 
     [
-        "5U4vxqQ69Vw1PrXSm2LkdLwWpMGT5yVmVLd5hwrYK151ZkwTS5QM24thQiKqwTp1tyRz99xdPsD"
+        "5UNT8i9DTP1mP7JFfLq3zTZsPY61ynZPoM9h5TDwZsn9CJt7Fsi"
     ], 
     [
-        "4wRDVgqY7eRCGJNMZPoxeFCgKhVV5FSC32nH4c2vAfW6XCNvb1V"
+        "67UGYC1w4E5MsAnuwM78WRi8Vhhzqw6HCeMJSz87gknwYioUe81EaVn1sbpVceyGrZezuNP8QJTsD"
     ], 
     [
-        "4eY1DUHtPWiSATDc375WYefbThaWXeHJwNCV5QVeK1UXC4PFgV4"
+        "PSmdYktxkyexXMFBJP8j4R91yAbVMTyAd3aAiN15pkgutxPchNgu6vBn4D9oj5U1vCxs1dkxa3X"
     ], 
     [
-        "3KkhuihpkFNoECRZfab4jt6FvqrUKZ15ykXWNZaUFr8yCMwvYSFcqLFCuHvdabsNwiNx9ossqgzpV"
+        "2gtH1dbu35E2zknoLUm7Pp4b73Sxe3fb8Qb"
     ], 
     [
-        "sgozZLczrTrH7CcXYGAGPRTxyKJNKd4h6G"
+        "5MxdLMambfVo4paPzjWH8xCtDKoitLweWT"
     ], 
     [
-        "CaD3jAqLYPQkua5vZFCzfkMo7zA3mGr9Br"
+        "3xdbNk7m1wtTy7NZbHPCyyGecnZtZa6dPMGR61KBdnXkg9GkfnnV"
     ], 
     [
-        "HPujzU75ULq5UJ9hLvdCTJABR97CnwrB4uypchBPqbjK6MqdsUdeY2qGqmaTtAFwXKw11C67vca"
+        "47EZCRZxvyR6dtqahaaE4tinvcaptyZ8UEoJk8duswssAwtgQ3Sb"
     ], 
     [
-        "7tkhUwphys8g14fLQjk1oaDKh6myXsXX1Hcn29k8tJxoyuj5RWGt"
+        "UxZEsYPa3yAxG8ZyY33cyq5pNrjXckG7Xc4jqMnhrEcXuZfd1VSZT"
     ], 
     [
-        "444C2meVcpEkkzPeiaVCSXH2D83rF1DZBJ67Hws1C5qRYvbEanUL"
+        "PmvnAA1vP6BbqokMch99PwZCHSunoowS6WSfYvV9b6kQ6PtmhTfGQr2tw78j4nFEqxvS67D7v9Z"
     ], 
     [
-        "WosLTdFHBNLg6arrhic2VhpA8apQ7rB4h7zy1wZqAaPNDPdoQ7pF"
+        "APCVktU2L4GC4LUWecgMgUiL6dZLXox7T4"
     ], 
     [
-        "65yomxwXZTMrxAvMES8t2BaPY9jtVA2WxKU"
+        "TZ7HLnEAv2u777VLqiZBNw8Vk543symwwb"
     ], 
     [
-        "66YM48ayapBSgg1thbF6pDTjXSjfUpyzcrBiAFPDg3o5Lx4TDVdW"
+        "7Qr9KZf3sGebioTfaYKJ8MwVyYMY26XkXC44B4VVrjQZnZSpPkf7"
     ], 
     [
-        "ULjQe1uQv6Nxfz3UBZLujj3oRYpLtZAqfUA8tUubqAQPLSZjq2NR"
+        "66LVr3B6Xhew6eavCrPZHa2Bfpqs1J82cS79h9b7fUJ8wBXyn3HXsqacohRw5BTiTJ5FgF6w8qRV7"
     ], 
     [
-        "3w9BrZ1946H7bmjDtzSEdJEXDMHywnCeASQ7cKBf4mafgS42XWyZdR8caCRGVtyvdeAdHpC3Ebk5P"
+        "Pb428qnFT8w4fjh1M74CBygWtGsb6BxUjGVL5oF19z1wmr3hZdq5ffuiudG1KfLHZGHCqyZLDo7"
     ], 
     [
-        "2c53qRjY7TMzcq44c1cxVaP69cBBS8sTDJt"
+        "VNTFf9QckTZorEf2VcYV4yeqoHw6xnXTQMzYD4KGYXg3kg2pZivB"
     ], 
     [
-        "3wcE3rZEyzZ2Wafs7BGYZT3cjHWW1yWZUphEccC4Ms5Wa24yWBYxG9ygbRFZCFSoexZh8gjdgns3t"
+        "PWAfMyFhgHyHgF6ftj3Y5wMme7ssPdg2ifaj1hBFamCEqEFpnpu7JVtukZCLTRDpzLNcwDxJyW3"
     ], 
     [
-        "2KJ359i2N9azMpUHTK4piEejLPL9Yz6cvx3"
+        "7ZszHnUobDYq91bWWqn4areCaEWUC1b4Xi9FutEP7jdXJdtbdoK23BnHHL5AsFvUpr6LmeoJYnn"
     ], 
     [
-        "3Yo6nS6Xcnj82iFxa2DmkF3UK8urGZMfmwc7dxE5tSk6gXMH8ee"
+        "6NY9PaMA5eW7VFGwfvBAz2QAGomsFAu2VPCgzmjt2wMHEq7LknE"
     ], 
     [
-        "GTndXRrvGhyWaQ623hScqcNbmfrcNRy3KRKLqBMm37kYND66Mz1e"
+        "256wGmtd1YpEUGJs6XjRibpnrBgQBEiH7e86umPTFBQzmwsirjn6EaUPd2uxj4uq7knjbUWLKtycsu"
     ], 
     [
-        "bYSMFCUpj52ccJ54CGEMfxnUTpZfYAqbBiktfdhZsqwcDLCvoNQW"
+        "9BB724Ax5166ZJpCYhJ1rVqb1AdP6RmSKxhKwLn6QW9YSATABgC"
     ], 
     [
-        "2TN2Zhq4WTF17YmjDVbZZgTQhwwcbSqdzWj"
+        "5MEbstr8dBuYbAaJDLE4veakd9fY1ggtSjAU3PygZiCpTZyQoXGDZsMmgZsFu2d3nkhyinAtbWWc"
     ], 
     [
-        "bvDG7JRPffvN1ZDos4jqrwqkur66ziSmedMegSh7ydo651easZ4rsHSefk5mXfi78ry4WKSnzsd"
+        "WgPG82qYhmVa1vkAW3eBgW8novme6gWN99"
     ], 
     [
-        "2hDxhEX8VFbvityBNu2vnXXWo9ZpA2Ea4sy3"
+        "rjgvyaNbXNgupcEmdw1C9GvYFjA4hqvmNnVMiM26VGeviRT3ZKbrLcftY7MjkbZ2cM5eKQK1zyR"
     ], 
     [
-        "HcmSzQWcbRPBZzN5idi2aKZeu4NYcC7sWqPCVhECCMMRDv2Hxjd6HpKXKBA5RWQMZVm1YbCw8j2"
+        "5ZAHnKFZf5tKyNgvm9ofHL3oMuUk12em5i6mezTUWv4FYQmE44b"
     ], 
     [
-        "6zbq9mKmoijBCjxdtJhoMQUo2acwUvunbjUN87X7wv3rudWyREF"
+        "6B2eo6QsnSU7EGjhF7pi5KpHj21rqDa2prUYvzHPuooJ8bALW7VfdG3we1JxqFwbFbjmCPi2zUE7i"
     ], 
     [
-        "3whBatp5RBqGmNdXkoFf3M9XZHaT1vs9D8Hu8fDh5WvCNsaEeprZFqXhUECaq3gEv7wRG3uc2Lw25"
+        "8LuFPvGyvqUB3bTUdFUciUrFp7PvQpoGeNj"
     ], 
     [
-        "gV8L6Zfk42vtxNBspgzquvyBkYLPJMFMUwZ"
+        "RwfmqHBEsLLDQcw2TRDMRpvAr8TxUEhBgA"
     ], 
     [
-        "3BPQvLGx63kbw3LZ9aC2KYD5xVZX86ibnsJA2tFiBJwY68Td36V"
+        "JGLbkk1DjpRNj5gwFUz2cCTtCRwyRWPEAn4KnADjN9vRv4Ej4Nc"
     ], 
     [
-        "MmAwaZSbVkj2dT5yTa2P7kYf6TRxhEC2Qf"
+        "7GWZPAtTxpraexuewCatmroYCBcRj59EdWH4JZykHSY1wpLooqDf"
     ], 
     [
-        "5P1piwARQ2ySVoTxXCJsfjEHDngZnQsSFdyLppBg9DpNfaWFi8TDuWQWxP9Gp34KThHZRjBdCcH"
+        "vH9N4qC1r7F4dc746Rw5cXphK9LYGbiUPv"
     ], 
     [
-        "8DjiJhZaak7qFhtGmgNxJiVGpiYTnA49JrG1tDrsjD4LYcKKKmh"
+        "5S8fasF4tQ7kgHvLyLeiJjwUanX8g69NmHa"
     ], 
     [
-        "DMsssXXfC9y29ybxe3EXwyz4LAZXkEeVuouPAenTSvcC3f2zL951f"
+        "UsuTRxYBiQwveaSG9mWigZzKSYAHtumkhsmT85wmFvqpnvwRgMYm"
     ], 
     [
-        "6QhCmnstho1Uw4rDiVjST38R65RGTC6QF1mxucahnsT85RP6BxZ6"
+        "7YLSQ2isz8TKYTWmkfxdY67QnGqTvmpkJh1wKT7HAcp9ZZ7q4D945JKTbnfSj4P94kRp96YsCZM"
     ], 
     [
-        "Lg9cFTAxz9MWMabKGqdZozvma3Sahcfm2nMzmYgJ8es4ZPboydaM"
+        "V1BFsaH1bHQ6zchqxK5PfwoE1qgU9JnaKZ3F7UW9TjsGCWywgfRUeKRZY7gMwAntVi3u5po5WLV"
     ], 
     [
-        "HZLZoaeckUFAnHpSFZtCPPX37UWGjfvz9ySkEwkrLBhPw6xQ3n3pdyBmqBo1rxsD2n9NHWTiHCv"
+        "HmUdm6u9UsA8orZuiGAnK9PpzJozDjyGfs"
     ], 
     [
-        "3SfpVac5bvynm1wGMhanJ2FUJ9h7TXiJroJp9hjxzHrtoRXDaMzZBmrCNbkHSFS1Qkc6DMShe3QNe"
+        "2BAvpMY5WL6CPH3b2BEoRnZGXLqjS8XuRBTuMmkRkSrGYiTtWxqArpUu8v1Rz5pKxyKrqorxykKm"
     ], 
     [
-        "3Db2Hve5VY5bVWBdXNYWUjwNakYh4wHnkUkdKe1JXbpKnyeGKaUvm8X5kyBMAdzxZgC2hXKzZg8nD"
+        "7PYQChAdCbSDibeL94jkRxsApo7ZB7y6dEa3TP85jHxrijeH1Lhh"
     ], 
     [
-        "bvVrSh6Kg2RWpfXvB2feNgdYmmXW4sMBb6UUXuzG33TvqVU1h9APYBc55Rh5gj1QGkeRzwhXB3k"
+        "FJdaQiFbDEounT3zATS8VmWUJQMyF1zVFrU5iujKLkb8fj53z969"
     ], 
     [
-        "2G965Bka1ACGbBMTUQsvbS1GzVYzFhEr4PG8PoMmuf6AkMUU28VZMjtjuCJG9Y6EP7ZT2m72K9BNP"
+        "QPB1Uuag5jiXFwiT34c9gB4RzdkyhAv8GinxgTsDH7inPnGE2o83tjrETavWAXAsW9xTuCQ8FfY"
     ]
 ]

--- a/src/test/data/base58_keys_valid.json
+++ b/src/test/data/base58_keys_valid.json
@@ -1,7 +1,7 @@
 [
     [
-        "GXjjVnVbJKeT7ZYYLmMRfhWH3Q9eJS1Tzn", 
-        "9866266029c07a424c77dd5cd2cef3a80993a9f9", 
+        "Sgf2AwXRSqhdgv6RzUXHnLAWLCZxY9VBcB", 
+        "d464138fbfd64103a6105628cfed45a6240a8169", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -9,8 +9,8 @@
         }
     ], 
     [
-        "3cYTdhbjShtbRtTwvUU8hywagNxpnKkoUa", 
-        "7e4e1ebd190107e880339b6628d7360681f59d8a", 
+        "8a3NGpj4d4JKi45ChQZz9o6nTfpNQcDr8A", 
+        "cff1cf03871edaead8a44f74542d72b090876055", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -18,8 +18,8 @@
         }
     ], 
     [
-        "gn3Nbewis9seKQrMFTFcHmKhrKUY7pZjVz", 
-        "da7d0b34a5b2a210002c9b9ea4c67b3f2b0459e2", 
+        "TP948XXz3U2bb4pqasEBQQuEULXjArc5Fp", 
+        "907663b46778d914ba27137bb82b0b74d585665e", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -27,8 +27,8 @@
         }
     ], 
     [
-        "5vfiKUFJP8Ns6yXGTatHc8mV3uf4MdcBhs", 
-        "3d8e2554c89e838d91c5847460c3441ba5614a79", 
+        "5U3Eyr6BN1RfFMc15Yq8FabY6X5FuHnk72", 
+        "1975147649a03e34f9fcf2cf747461174bb53ea3", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -36,8 +36,8 @@
         }
     ], 
     [
-        "2ZUw6SW3of8fJw8FMuKGZn9vbWHDPF2YEVrgvRgqNCRqKtzpnU9", 
-        "8c12b56c537d16cd824e1f29569c35d7e529f0600c93398b238b00bb96e18787", 
+        "7RbasFxpdXMWVL1gEdYuSdEoXU7corNosuaCbqcn8r6GuUXvAmh", 
+        "ad797546fbffb59c4e89da247f20ad09027b65450669a43ca0ae72984bfca7a4", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -45,8 +45,8 @@
         }
     ], 
     [
-        "7s7e5kzaXQ1pbzfZRSiW3ZB2euJv2XDru5ezBEWUb8HG55JNvu6Z", 
-        "66b30a4870698181a36f9781a34bb8f051649576118af7c0ed2382db34126fb1", 
+        "VPRMWDba52UxG3ruGSqmdPKPghShHk8TeQseqV7nkKzsS7UJ2es5", 
+        "e4e2171773e93d26ccb43e5f0565548464caebbb1668d6a710e76c507fb50e73", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -54,8 +54,8 @@
         }
     ], 
     [
-        "4cwwRnD32crrH2Txw1g1a4WH9HEfvpFaHeejcdSnrmY8U1w2r2q", 
-        "013a709450c96b78b51e3396b72c96f36e8ac01381a573a312f38f4f7582b528", 
+        "7KWCu7o4qMYfHvG3s3yAEf3fEm8HAHFXc5Jajs3XVoyiDoLinN5", 
+        "8b15b1f337c80938fc807ea63b23eed610dcb77453b2c024ef60c79deddba5c3", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -63,8 +63,8 @@
         }
     ], 
     [
-        "H3QUV6goNPjFBt585yiy8yj9syT6wxgC3RDiV7ppZQnNkamZDQXR", 
-        "70dacc610a2524e872cc7b8a7010adb9bd75563232a002765a81873d8acf15eb", 
+        "UqdvgVnM8182TY6wBwKckxKJz29ydkJY61HddhUrhnzZiaZWmwfi", 
+        "308dd2c97e4b6687d35f520a4fb584be84b3be9373c4b565c2965ffc07638f3b", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -72,8 +72,8 @@
         }
     ], 
     [
-        "GdccRcRsAzXqYzusbGQGuACkNH655H6HeH", 
-        "d8de16e9a00fdf7aff9c1c8ed365cd842ac6dca0", 
+        "SW4E14n75TvdLbD6fqo6vTMbCrXao255xS", 
+        "601e2287b792425e4dd2cc5d7ae3628b64f08f35", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -81,8 +81,8 @@
         }
     ], 
     [
-        "3SD1Yn1VKvsbaubWaQKVDXdMLQBH6wDGPL", 
-        "0cef2f33f332708a75a286344d80b31ce43d98cf", 
+        "8KApFzw2pL1krrLc16RZcwJDbHy162fRwA", 
+        "2cd086853fd12ef7fe30cc7f52a27f08368a9417", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -90,8 +90,8 @@
         }
     ], 
     [
-        "gjdDNuAsHCa7DkD6ySWiVA46Fx6BuZq2tj", 
-        "bffb1cdbd3473153acb74a4d712afaa46f54cc91", 
+        "TFUJpv9ndQLf4wUCzeGJDVSYcWqCK7FbzM", 
+        "3c598decc7faabc2ece06481020b5bc3e9c8fe38", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -99,8 +99,8 @@
         }
     ], 
     [
-        "5wiu3wSQZxTLj14bWCX3DYamcq9JVDtQKp", 
-        "49207a71efbc146dde0e2bc3ce472291be60c2a6", 
+        "5nBiuC33pHS356fPwj4uybx65Qm2tL6qdE", 
+        "e081fa5a7526b47c3cb2daa66302a10c0aa86d59", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -108,8 +108,8 @@
         }
     ], 
     [
-        "2ZFAicUXCg81q7CMVreLydp1vBfsdDH8Yoi2rESFvjw855bxPav", 
-        "6cd155d55d2f774d7f3e138640e10c96c2c8b6a738eb55a61af47e7e10951748", 
+        "7RQYcmK4AjP9UpP9WjfKRyK9J537XXrY1UfRqLwdidEtMymQe5e", 
+        "9468d647efbb1e0a21e0e8d3fa031ba3647289e55ed36d1592e76da37075701a", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -117,8 +117,8 @@
         }
     ], 
     [
-        "7prKE4PuVPA6VG89FCdHwFJ8wvrnZPU8rWvX1E9shq3dJE1HnWPG", 
-        "232408e82839d466d6b10a84bf836c843cc42d3a748ef7f8385ff8a59cb6362f", 
+        "VGDLHVMe6Qf5YgEpa5sVbmr431J6xmedsisooQHrhqnAZitRwg7r", 
+        "0dd65a7b2cb3e2a5f7d0d9fe5b6ffac99f12fb6261281881a4e9d49403b8f55e", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -126,8 +126,8 @@
         }
     ], 
     [
-        "4efN6aeobUci4BH2CHyrnniqddeAiZJisiXZ7ds8reoTQhEU5fJ", 
-        "e2fc537a6ebb331aca09e5a5e11c2b86e9ccd096bb58e706da3484ea2244104c", 
+        "7JUPQXotkh8NjzejkejT9ZWNeNkhVNMn64c9HkfkWMWdYiJdzvT", 
+        "03423d3de98dcf688bd42a202442d5b39dfbe0b2a17d0bc7649a0bdb47a5319f", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -135,8 +135,8 @@
         }
     ], 
     [
-        "H6KzZ5MR8RPLzWRyMfzpq8UWSRrnPystTgVg5htb38skta3ecJdb", 
-        "c80fb67be95a509f10266aea01db48ce2e61274ff1dbb239b1542851b869f3c2", 
+        "UuVnbXZ4y7B8hHST5T67WPskYu4LskVnUyXWVU6WAiKxV2ncfw76", 
+        "a3b763a35ad1b842c99d461547839c5deb9e5b483c85ed05b1692c75a7bd8d02", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -144,8 +144,8 @@
         }
     ], 
     [
-        "GK2zWBh2Xq5DxzsAUQDqs4q2bPrcRpYSFh", 
-        "0d101cfa238722eeeb90442bf215171ed16f62cb", 
+        "SVqo8hhP4u2y1PwTpuS91yXQPsefS7qeq4", 
+        "5dc4626186e6787b5982b011662abd97e4ce7c18", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -153,8 +153,8 @@
         }
     ], 
     [
-        "3i1WQrVGTQ7cXR1F5EefbjoxBD17R8sLnP", 
-        "ba444ca17610acc01fc671fc353f2a7a8af8efb2", 
+        "8WfYR7RDAiunFfwUMGoHYMJm7VAoVjcroW", 
+        "aae8bf3b3c359b7551257d2147686fb4c49341a9", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -162,8 +162,8 @@
         }
     ], 
     [
-        "ghq5QFL6a9NURqSRSECdpKUZHmax4r7evj", 
-        "ac4931ac3a6561b113e9d38621c335693856a800", 
+        "TXSQmctWuttxHAQA5ubNjUJu5MisTbEymR", 
+        "eb7fb23379b3bc2311a045d40e51b5cecbc46877", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -171,8 +171,8 @@
         }
     ], 
     [
-        "6DGfFfgBafQQPG9momBpQuENfSjZHCoE4T", 
-        "f3ac28740ab7cc8b150a7f0381a699307c6736dc", 
+        "5ko3DGnQsEYSDRFzL2a8T59Ec3vFbdaAaU", 
+        "d13f9227f2edb5b77799a90a7b29878404a588b6", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -180,8 +180,8 @@
         }
     ], 
     [
-        "2Z6n53xz1byBsrT7UMqyTm2UL5bmiahSghsupFH4yy1ZnQcChka", 
-        "59c42010de222942ce832ea0b0f0c3b2abe79a2915d053d61432d1dd55961280", 
+        "7R3B7YEUW7gWouyknvdNahuCWUFCuxQkDkwBJPnESaoAmtHAF9b", 
+        "63e2754b28ad22530444069eee0aba9a11138e8f8e1c75281274d8b5529448ea", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -189,8 +189,8 @@
         }
     ], 
     [
-        "7qi6c93B7xsT92XQteULUVesHxmm6NEj9h1Cqz7Z4YunFyexmDXz", 
-        "3cc02f955043b566e66112b24ac19bd14fbb1e0bf3ef3b1448cca6aeee955ede", 
+        "VKXsSLVhzepnf3kBwY5DCfvanSDQYtwCPo6sXTGL4qPZcsdJPRC6", 
+        "70e2bd48ccb1c72abc5e34e49457955a704f5fb46610f113ad0564b9d5829a82", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -198,8 +198,8 @@
         }
     ], 
     [
-        "4ekysUMtK2CyHHBUqRZecNfvnA8eHkr16uLjUdfDmmx6QqTvPk4", 
-        "efbd406d19cdc2e33a24f4bd4778e305ec4337372612174a8a5e976ad6d75ad8", 
+        "7Jn2G5QF6uJ4i1fcmg7VcAsydxWjxTdxo7XCsEQPYsWGTbEYbMy", 
+        "2b4d57bbc0ca1767a1c9bc3c0bc03ca75a9e575f9e5584a3f77b2159f9ac83d8", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -207,8 +207,8 @@
         }
     ], 
     [
-        "H4HLtgJNg5JnjN5DkmsEmZnuQWpfWmnT5aXfTSKycu5J5vnJyxQ3", 
-        "8b060eae33a81a7735b48e3af02df363671ce00716ffcf97f1984e9a68e231bc", 
+        "UvUWSiYGRBHpTyHCgoMB6ePXxMKcGUrHeRka8Tx7FsKTtbnsEAsR", 
+        "c0e5644aadadfc3dde3a37f05e2f80cf04375afd9bb86dec5cd91259e8f62d52", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -216,8 +216,8 @@
         }
     ], 
     [
-        "GPpCBUx8LQbD86K3HGsDX1F9wXb4NpnLmW", 
-        "417d1520bde5023109cc610751243b2894b323be", 
+        "SaYECz1WsJt5obsFhf4bXqsb2HtYi5bHox", 
+        "914a74db7742977d133de03ed598fecea24a7deb", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -225,8 +225,8 @@
         }
     ], 
     [
-        "3ho6X1ZYnxb6JaX16NmNy1rvfRh1FK2AZ8", 
-        "b7eb5cb9ed928ef0e6ae6344b63e51609fa6cabd", 
+        "8KHZFWxMhPRfJNoFkvDTqrzkfoVCd7RcFj", 
+        "2e16e8ad1c1a461e6ef42bb6569cb0698c98b4ef", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -234,8 +234,8 @@
         }
     ], 
     [
-        "gjycXiWiQqr7Z8kzQyR35K3ZyAkm8j1K58", 
-        "c3d6c21ef5b299e756fc96d21ace81a11e8ea931", 
+        "TNE5VV8teJ4gXMidoQPMP7W4CXXaqALXin", 
+        "86717adab1716f7761b6c4f8d9ccb68ad16846b6", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -243,8 +243,8 @@
         }
     ], 
     [
-        "6AseLG8vZnSncQJUsPdUhmf8Kq8y6o2KuB", 
-        "d96192190e4d78db52a361ea72a933d9d085d03f", 
+        "5dQ5HJCP1XK9Murxy2vRkiNbVZWM3X3A8Y", 
+        "801ed9caca9da83118ee2ccbaa349bac20b7385d", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -252,8 +252,8 @@
         }
     ], 
     [
-        "2Zy59LfSGD8vBtxy6aZqePnN4AgSftkLHgc5YUccpfGU8EZJmUa", 
-        "cbf734fee12267b3253e8a48f91feabc97cd12e5d3dd49b825db9ecb2065165e", 
+        "7RgttWfGA1fWk747YKqs8wP4vJpgG7CSnhymMzSvH2QkMBpiMXm", 
+        "b98877e330e64889cfff8c440dc09b607941751ddcbc53b11cd9ee2325fb5cf6", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -261,8 +261,8 @@
         }
     ], 
     [
-        "7q2UE5WjLHEVB8zmmCQZEbfh1iunSSyBytX14J2kREpNCzDRtV6P", 
-        "285d6e9e2bc921cda377ea3aaeac53c7b2438a0f7b9f751583b9f4b49f8cd467", 
+        "VH2NV1X6MnL86qSWk1vZvzLdLM6A5PD3c88aXHkm9j3gg96j1Hfr", 
+        "26090fe9ca6636f040c2fc6b76f8aa9bca2bbc6be96b56a1d3f8d67478dff678", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -270,8 +270,8 @@
         }
     ], 
     [
-        "4dwjQxhWv8JkY5F89yqV6da6FD7BYQYwCZhqw9yc3cBCrA7hKd2", 
-        "84743be367d83929c238e2cc41c684d45820f22839cc7b7de0f3d15d1c424098", 
+        "7KDGq8T5uBT3MLkKFeFejjuSSDBFECiRy33QcAimhccBfB2PTQq", 
+        "64a35881b7ab1a0d8859afce9b43977674077f601abe08db91eb12969358b109", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -279,8 +279,8 @@
         }
     ], 
     [
-        "H3CLSq7SxX7T15qkkhRgZEj6GGDmocLT3KxRD6SGCURTWxkLDhnp", 
-        "6a9c31011b555ac9d8fd79279a589f004663b4910b79932e644bba823e2f3c04", 
+        "UqBK4LoT9ooLZnL8wy3kLpyfw69ZnSXVbeomsRzGz8PqbvvMuftb", 
+        "22dcd674631ddae06e9d6d3a5e5bc63e648c871dfcf9ac327a6428760b2b0b91", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -288,8 +288,8 @@
         }
     ], 
     [
-        "GLQVnZqrsvP48P3mamypaEvkJemRay5jFg", 
-        "1c196afd66a3c9e62d1386b5ff3497ce8fcf8ebc", 
+        "SihTg9yFwzpD4xYV3EmZY1yEJ94n1T3P6Q", 
+        "eaca73069c5edd5e4b34bbf505f0333e3cbe63ea", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -297,8 +297,8 @@
         }
     ], 
     [
-        "3nDWDTkK2ThTvYFnb3gdKxzRFpcVVKUyKM", 
-        "e869a14b5c4e87e112fbc2f125c8d466ef1b85ef", 
+        "8VH4osTFR3CFKLx9nsDNRGEJ7m2GSUTYAw", 
+        "9bb06ca4e280d42ae02b01bcb3ef3b893efdb652", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -306,8 +306,8 @@
         }
     ], 
     [
-        "geMfhGAGbYLRrW8pNiLShWSzskdEwRcmo1", 
-        "8631cbe0dfafc32c3e850c971b8c949d0796d85f", 
+        "TF1Px6PHxjQPfpdyEtQ1g9sxy1FnX9J1WN", 
+        "374299ba796588b3046677d3872f78f2096241a6", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -315,8 +315,8 @@
         }
     ], 
     [
-        "5wUZsjMGiBR1L1nDMB56cVfL2AFSVtqrVL", 
-        "466aa5c34b86118441e4643ab83f5d2f7f4f90dc", 
+        "5iRF19hGaYgwVB6zs1Dw6oA6Dd86ugahFQ", 
+        "b73002c54e1e96e858a5a85f26dbd990e82a1df7", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -324,8 +324,8 @@
         }
     ], 
     [
-        "2Zj2DwejDkwXW6ahTDCVcaTgpnFyfY8HmAk9MH3gV3mfiS4TtWM", 
-        "ac10069bb2ae840eda3b541ec342e930bebb9dcaf82fa93706866a6b44457004", 
+        "7Qs7KQRgguqABzUWcPsSNZNWNXkvFrpb5DziEVoDztrqKJqt6sG", 
+        "4d07a08636dfaf9ad29815ef7d2f0b208dec6da12ae2db0a516980a590661209", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -333,8 +333,8 @@
         }
     ], 
     [
-        "7qF3s3HM567ZGMEfFUBP1QsR6J6zyuAVs7SkUwFn4eX3tLa49WXQ", 
-        "2ed629abb8fe47e18b39ca3f4ccee0b87e1cf911c967929d4b1f3a8e85581590", 
+        "VP3Bcd6Ty9UGUczerPea4SVNE4i84XLVEcmn3njw9VYV8S4RM3Yr", 
+        "d97a5215123b3bd3fd8864f3ccbde4856880ec6845f1ee8565aa5278be48e2b2", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -342,8 +342,8 @@
         }
     ], 
     [
-        "4dp3CdD92JP8EAsELwg9xbtcHqezjng4FBMrFRBFfWieEnKiFNR", 
-        "72fc43cc73e7afc4d061fd18c485bd463bda236295177dbf8f25cd3cade54114", 
+        "7L5vii5EsG8MLdJjWCYVNsVKn2qv5RXfum6rUSYvCo7jGGEFgoL", 
+        "d7a70a5635dbdb2c4afdf9def290ab093b45136d20daae3c59d34ec45b6b0dfe", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -351,8 +351,8 @@
         }
     ], 
     [
-        "GygKE8NaDBrMkVVjyt9A4fBsziNonPYaHJbGRWSxSXG2pWXGC9kY", 
-        "01a76b89fd94b53dd1f5f73cbdb1792f30038c929bf6972b1a7ccb36065d1aae", 
+        "UtTyrnzdiTDXDEe4645eotsJQsLk7mo8PkJB3zxC5aasuyTJC8Wp", 
+        "84f332af7ad3d1327cc4071055c51914f4cf8681893834a24ac6570ba9d6f765", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -360,8 +360,8 @@
         }
     ], 
     [
-        "GNEjCfko6zJFy4r2h6XmwvuH6w9yacaNcC", 
-        "3030b567e4cc55fa8b4598fa11c5ea4888522d88", 
+        "SeNvcYa9zkZhNyUW4YWr5F6tJgWSUUskWk", 
+        "bb688787b4a6ba6ffcec2129448553df950d0abb", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -369,8 +369,8 @@
         }
     ], 
     [
-        "3my3fYTacGS5y3DkLWJXhXGXEqApXh3wsa", 
-        "e5ada4bc3a43d0f2784bad62266f67289dc887de", 
+        "8YjxpmsHMkdRBNrdVh9YDWxV5HKmdDnsee", 
+        "c1af0983ead9e67a9609dc2786d632f2f2fbdba3", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -378,8 +378,8 @@
         }
     ], 
     [
-        "gT2nQSQvNpcVc9UNfnHWsMzAcaWxZTtVjU", 
-        "09f61c55c822b8c9eed7d64f0f25b98bdb9b1bf2", 
+        "TLxzt539LpUayCkYaLoAw7tdubd5XHJf7C", 
+        "789f4414e346af7c7bbdcd34e94830ee2ec35ccd", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -387,8 +387,8 @@
         }
     ], 
     [
-        "661nPC2geafAu4T8GGtH7qzDyqTff1TpGs", 
-        "a412fd5c712e909bda77ff1b758669420aaa48b7", 
+        "5hBxRfRkSbkRVjbDZsLkKytStdirqaincq", 
+        "a9b4a3b2b7d0bec49eb9448cad9027d0f10c6677", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -396,8 +396,8 @@
         }
     ], 
     [
-        "2ZaA2czESSi1YKmgTUmCWrEFVSyiz5wmJR5KCvRoN8HqQtnJxHL", 
-        "97eebb696c3184270e38d5d7a2540b2f37818185aa3dff91c66ee2058ac7f4f6", 
+        "7RRou7zoF5cct3ZmJVMK89y9vdzaDq5gGc4LnHFpWqG4HvKQ4Ay", 
+        "97474606ce329014749ce7b1f6e3437e4d13735ae705218f76d5c1d6c0642551", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -405,8 +405,8 @@
         }
     ], 
     [
-        "7r8Lkt6aBkcSduTHmwXEmu8erTktuTUZnRC4ddEzx14r56JKVaEn", 
-        "493905eb882c6194324e38b971bd34b0cef5002bc8c036bea284accf1b9d49bd", 
+        "VLdT7KvDnunyX9pwUXKjViBtoPeqZ4au44HXVhW63gkyYhgpQM8v", 
+        "91980ce337e88f0a68da974ac744be1f1e9a2877d1cd697cfb8c23f1f9a15f95", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -414,8 +414,8 @@
         }
     ], 
     [
-        "4dYVbbJjwp9DuRSMZGT5oBycuCoYg9ifHAr9NjZfjAzvmJU4c2g", 
-        "4fb0567cdd1a8e8a18023eb5db737402b13519e40ad97e0a7029b296731ddeb3", 
+        "7JhnQshQggBSqjsXg18vmtsA7YDWSLD2u2x3wGEAqXFBUqSE6oF", 
+        "21ad6fd9c9135dc4a53bdd9b080f0cc2c3e8b7e9690a732dce5c64278a745438", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -423,8 +423,8 @@
         }
     ], 
     [
-        "H6m9EKiTURYtRUp2Q6ALgSYSqLnYhK4kLZfxVEnmXsjgc4PBpWfv", 
-        "d4ffd112145e6bcefbb8c443874680314f2302d733bd7d01e045e6e353c715fd", 
+        "UqRFh7ddWjMgMokjLVv53hRZBvmjcfQDRZgcJBfT2k7LJctzqEdM", 
+        "2a08f0aefad7171c0cbff9f4b06de2cb020fb72832cacc341aa4862d4734d5d8", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -432,8 +432,8 @@
         }
     ], 
     [
-        "GLNmXi5XrbU5bdAERWv7YmQ1Hph314a1z5", 
-        "1bc5ba714547ff3129afca6d37ef95451362c4b1", 
+        "SZ2sReujc9ooRYqmghaYehqhkiDyUpvW3x", 
+        "80c4eb9500ec42e73b096cedb86287cf28811408", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -441,8 +441,8 @@
         }
     ], 
     [
-        "3ndqTr6ikXXWykZBwzj4bLMQqmvGEk9Mym", 
-        "ed03ae3a809d234b9d94241bf6ce5ca242eb3757", 
+        "8JPgompPF54AKi2wnJ4Tu77St6njVtA6iv", 
+        "244796202a635438e83e92285369141923872ce9", 
         {
             "addrType": "script", 
             "isPrivkey": false, 

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -17,14 +17,14 @@
 
 using namespace std;
 
-static const string strSecret1     ("2a6Rd6XtMKvFrjkDi6FcfSrJkpaKc382bCDadKjxPsSAHKXoZok");
-static const string strSecret2     ("2YtPcre7RfCg6TdakgACcAiFBakczN41n1D68nvseWST5eVqqxU");
-static const string strSecret1C    ("7w4wgKRKeiW4aXfm6NBWQh6dNQz57eN21vWXRKibVwc3xfUaExcT");
-static const string strSecret2C    ("7qjpqG6oMqcXZ6YTymqcEDs3bhyXrBvJRdvMfPinYYwL7HbEPDnQ");
-static const CBitcoinAddress addr1 ("GPbEQ1hJxpJkWBDKMpc4y2KkugwuUaRUTY");
-static const CBitcoinAddress addr2 ("GMLyt6XF2uyf5D154j7VW8oYGbcmvREGBm");
-static const CBitcoinAddress addr1C("GRswJtXD3dWyWpz8oXdbxWeTEvYAuXmQUx");
-static const CBitcoinAddress addr2C("GfpzbEUtk8je9RvaSMuCkScEU6fvichQLm");
+static const string strSecret1     ("7RyykSAJ6rjEbrd6af1f3sW5jFgvuKZgKjT278EtNKu8TYc6GRi");
+static const string strSecret2     ("7QVdtzDK4beP8GiFxuTjHrXEfb5StR8DNHsQMNShspzJkUGqo3Z");
+static const string strSecret1C    ("VPGVUi42UrVR2r2KdYmtwfuMsVqEuvwEZgMqt2xHj8R5v2BGCQQh");
+static const string strSecret2C    ("VGhPrTXLisuzf6M73kYyfPaTKKQdFwUqayTU4ueTRLowLeHJKcB5");
+static const CBitcoinAddress addr1 ("SRyT5tbS9VeSwKM9ZTrBR1pUWj9xCxvDS7");
+static const CBitcoinAddress addr2 ("ShVhSJghDSTXnazvUjZZS3QwrU3DkyiRbr");
+static const CBitcoinAddress addr1C("SgSQegGurMWSL5vTkosgCUzQicmpsiAaep");
+static const CBitcoinAddress addr2C("STb1mLGsrP79hjP4pLU7iGngs78g7JKoYD");
 
 
 static const string strAddressBad("Xta1praZQjyELweyMByXyiREw1ZRsjXzVP");
@@ -172,19 +172,19 @@ BOOST_AUTO_TEST_CASE(key_test1)
     BOOST_CHECK(key1.Sign(hashMsg, detsig));
     BOOST_CHECK(key1C.Sign(hashMsg, detsigc));
     BOOST_CHECK(detsig == detsigc);
-    BOOST_CHECK(detsig == ParseHex("30450221008e7fe2176fc31d4c8ade9f7f07361409eff432d62e98dce653a95850a7793f910220487bcbf390003988a0cc46f3ed2bf013b78ca3a40406bde7991004487ba58695"));
+    BOOST_CHECK(detsig == ParseHex("3044022040b0ca2120198f5a15abacce9b6eced0137aef8ff229b515cef77c21d8937b1b022020d3c7b033875efe5dcbd1f4f560cdc6f9c5228f615f3fdde2d69c40bf52ae11"));
     BOOST_CHECK(key2.Sign(hashMsg, detsig));
     BOOST_CHECK(key2C.Sign(hashMsg, detsigc));
     BOOST_CHECK(detsig == detsigc);
-    BOOST_CHECK(detsig == ParseHex("30440220469e065172b99b782ac742d54a568867eb13274864665e605272a8f11c696cdf02205892001019e2813b39887c3f5e67048751b16ebb5fd2f9f3a38639538234e4f1"));
+    BOOST_CHECK(detsig == ParseHex("30450221008d56eabb4b7d6d78ea1fe5e7fedf4551ebcef0423a81b03a3b4f386642194b12022017a197dbba26e05158100dc7e755a2a78a38ba41d67cb8b181e59ba4c316072d"));
     BOOST_CHECK(key1.SignCompact(hashMsg, detsig));
     BOOST_CHECK(key1C.SignCompact(hashMsg, detsigc));
-    BOOST_CHECK(detsig == ParseHex("1b8e7fe2176fc31d4c8ade9f7f07361409eff432d62e98dce653a95850a7793f91487bcbf390003988a0cc46f3ed2bf013b78ca3a40406bde7991004487ba58695"));
-    BOOST_CHECK(detsigc == ParseHex("1f8e7fe2176fc31d4c8ade9f7f07361409eff432d62e98dce653a95850a7793f91487bcbf390003988a0cc46f3ed2bf013b78ca3a40406bde7991004487ba58695"));
+    BOOST_CHECK(detsig == ParseHex("1b40b0ca2120198f5a15abacce9b6eced0137aef8ff229b515cef77c21d8937b1b20d3c7b033875efe5dcbd1f4f560cdc6f9c5228f615f3fdde2d69c40bf52ae11"));
+    BOOST_CHECK(detsigc == ParseHex("1f40b0ca2120198f5a15abacce9b6eced0137aef8ff229b515cef77c21d8937b1b20d3c7b033875efe5dcbd1f4f560cdc6f9c5228f615f3fdde2d69c40bf52ae11"));
     BOOST_CHECK(key2.SignCompact(hashMsg, detsig));
     BOOST_CHECK(key2C.SignCompact(hashMsg, detsigc));
-    BOOST_CHECK(detsig == ParseHex("1c469e065172b99b782ac742d54a568867eb13274864665e605272a8f11c696cdf5892001019e2813b39887c3f5e67048751b16ebb5fd2f9f3a38639538234e4f1"));
-    BOOST_CHECK(detsigc == ParseHex("20469e065172b99b782ac742d54a568867eb13274864665e605272a8f11c696cdf5892001019e2813b39887c3f5e67048751b16ebb5fd2f9f3a38639538234e4f1"));
+    BOOST_CHECK(detsig == ParseHex("1c8d56eabb4b7d6d78ea1fe5e7fedf4551ebcef0423a81b03a3b4f386642194b1217a197dbba26e05158100dc7e755a2a78a38ba41d67cb8b181e59ba4c316072d"));
+    BOOST_CHECK(detsigc == ParseHex("208d56eabb4b7d6d78ea1fe5e7fedf4551ebcef0423a81b03a3b4f386642194b1217a197dbba26e05158100dc7e755a2a78a38ba41d67cb8b181e59ba4c316072d"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
      * 			setaccount
      *********************************/
     BOOST_CHECK_NO_THROW(CallRPC("setaccount " + setaccountDemoAddress.ToString() + " nullaccount"));
-    /* GJXR4SmmCivt4KUC5b21zfHm8VHw3JtR3h is not owned by the test wallet. */
-    BOOST_CHECK_THROW(CallRPC("setaccount GJXR4SmmCivt4KUC5b21zfHm8VHw3JtR3h nullaccount"), runtime_error);
+    /* SX7ex6vUHtw1y5hYrzpAXrM4vthtBk7yWr is not owned by the test wallet. */
+    BOOST_CHECK_THROW(CallRPC("setaccount SX7ex6vUHtw1y5hYrzpAXrM4vthtBk7yWr nullaccount"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("setaccount"), runtime_error);
     /* GJXR4SmmCivt4KUC5b21zfHm8VHw3JtR3 (33 chars) is an illegal address (should be 34 chars) */
     BOOST_CHECK_THROW(CallRPC("setaccount GJXR4SmmCivt4KUC5b21zfHm8VHw3JtR3 nullaccount"), runtime_error);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     BOOST_CHECK_NO_THROW(retValue = CallRPC("signmessage " + demoAddress.ToString() + " mymessage"));
     BOOST_CHECK_THROW(CallRPC("signmessage"), runtime_error);
     /* Should throw error because this address is not loaded in the wallet */
-    BOOST_CHECK_THROW(CallRPC("signmessage GJXR4SmmCivt4KUC5b21zfHm8VHw3JtR3h mymessage"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("signmessage SX7ex6vUHtw1y5hYrzpAXrM4vthtBk7yWr mymessage"), runtime_error);
 
     /* missing arguments */
     BOOST_CHECK_THROW(CallRPC("verifymessage " + demoAddress.ToString()), runtime_error);
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     /* Illegal address */
     BOOST_CHECK_THROW(CallRPC("verifymessage GJXR4SmmCivt4KUC5b21zfHm8VHw3JtR3x " + retValue.get_str() + " mymessage"), runtime_error);
     /* wrong address */
-    BOOST_CHECK(CallRPC("verifymessage GJXR4SmmCivt4KUC5b21zfHm8VHw3JtR3h " + retValue.get_str() + " mymessage").get_bool() == false);
+    BOOST_CHECK(CallRPC("verifymessage SX7ex6vUHtw1y5hYrzpAXrM4vthtBk7yWr " + retValue.get_str() + " mymessage").get_bool() == false);
     /* Correct address and signature but wrong message */
     BOOST_CHECK(CallRPC("verifymessage " + demoAddress.ToString() + " " + retValue.get_str() + " wrongmessage").get_bool() == false);
     /* Correct address, message and signature*/

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].nValue = 5011; // dust
     BOOST_CHECK(!IsStandardTx(t, reason));
 
-    t.vout[0].nValue = 6011; // not dust
+    t.vout[0].nValue = 300001; // not dust
     BOOST_CHECK(IsStandardTx(t, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_1;


### PR DESCRIPTION
This patch fixes the test data (e.g. addresses, hash algo, etc...) to match specifics of SwiftCash. This allows the test program to pass and have successful Travis CI builds (see passing https://travis-ci.org/glemercier/swiftcash)