### PR TITLE
Protocol Upgrade & Min Proto Versions (to drop previous client connections)

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -16,11 +16,11 @@
 //! These need to be macros, as clientversion.cpp's and swiftcash*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 1
 #define CLIENT_VERSION_MINOR 0
-#define CLIENT_VERSION_REVISION 0
+#define CLIENT_VERSION_REVISION 1
 #define CLIENT_VERSION_BUILD 0
 
 //! Set to true for release, false for prerelease or test build
-#define CLIENT_VERSION_IS_RELEASE false
+#define CLIENT_VERSION_IS_RELEASE true
 
 /**
  * Copyright year (2009-this)

--- a/src/version.h
+++ b/src/version.h
@@ -12,14 +12,14 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 80411;
+static const int PROTOCOL_VERSION = 80412;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 200;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 80411;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 80412;
+static const int MIN_PEER_PROTO_VERSION = 80412;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 80413;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
See comments on my version.h commit. We could go ahead and change most of those values to be unique to SwiftCash (starting them at 80411).