### PR TITLE
gitian: fix missing end of 'if' block

### DIFF
--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -330,6 +330,7 @@ then
             git commit -a -m "Add ${VERSION} unsigned sigs for ${SIGNER}"
             popd
         fi
+    fi
 fi
 
 # Verify the build


### PR DESCRIPTION
This patch fixes the following issue when calling the `gitian-build.sh` script:

`swiftcash/contrib/gitian-build.sh: line 413: syntax error: unexpected end of file`