### PR TITLE
Fix UI transaction history when a transaction contains two outputs to the same address

### DIFF
--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -100,6 +100,11 @@ public:
     {
     }
 
+    TransactionRecord(uint256 hash, qint64 time, Type type, const std::string& address, const CAmount& credit, bool involvesWatchAddress)
+	    : hash(hash), time(time), type(type), address(address), credit(credit), involvesWatchAddress(involvesWatchAddress), debit(0), idx(0)
+    {
+    }
+
     /** Decompose CWallet transaction to model transaction records.
      */
     static bool showTransaction(const CWalletTx& wtx);


### PR DESCRIPTION
When a transaction contains several outputs to the same transaction (even though it's an unlikely event), the history tab in the UI would only show the last output amount but would display the total amount when clicking the TX for details.

This was due to the fact that only one entry was created for a single transaction, and the amount of the last processed output would override the previous ones.

This patch addresses this issue by storing all created entries for each output, and check if the address already has an existing entry before creating a new one. Instead it just adds up the output amount to the previously stored amounts.

This patch should also address the other specific use case (even though not tested) where a transaction contains two outputs to different addresses belonging to the wallet. Before this patch, only the last output would yield to an entry in the UI since only one entry would be created no matter how many outputs belonged to the wallet.